### PR TITLE
#39 created a layout for matched students

### DIFF
--- a/app/public/js/dashboard.js
+++ b/app/public/js/dashboard.js
@@ -1,0 +1,16 @@
+function deleteRow(r, tableID) {
+    var i = r.parentNode.parentNode.rowIndex;
+    document.getElementById(tableID).deleteRow(i);
+    checkEmpty(tableID);
+}
+
+function checkEmpty(tableID) {
+  mytable     = document.getElementById(tableID);
+  mytablebody = mytable.getElementsByTagName("tbody")[0];
+  firstrow       = mytablebody.getElementsByTagName("tr")[0];
+
+  if(firstrow == null){
+    var div = document.getElementById('ifMatchesEmpty');
+    div.innerHTML = div.innerHTML + 'No matches to display.';
+  }
+}

--- a/app/resources/views/home.blade.php
+++ b/app/resources/views/home.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.app')
 
 @section('extra-content')
+<script type="text/javascript" src="/js/dashboard.js"></script>
 <div class="col-md-9">
               <div class="panel panel-default">
                   <div class="panel-heading">Dashboard</div>
@@ -28,6 +29,30 @@
 
                   <div class="panel-body">
                       <!-- Display matches of people with the same availablility & class-->
+                      <div class="panel panel-primary">
+                        <div class="panel-heading">New matches for COURSE_NAME1</div>
+                        <div class="panel-body">
+                          <div id="ifMatchesEmpty"></div>
+                          <table id="matches" class="table">
+                            <tbody>
+                            <tr>
+                              <td>You matched with USER_NAME1<br>for availabilities from MUTUAL_START1 to MUTUAL_END1 &nbsp;<td>
+                              <td>
+                                <input type="button" value="Confirm" class="btn btn-success">
+                                <input type="button" value="Decline" class="btn btn-danger" onclick="deleteRow(this, 'matches')">
+                              </td>
+                            </tr>
+                            <tr>
+                              <td>You matched with USER_NAME2<br>for availabilities from MUTUAL_START2 to MUTUAL_END2 &nbsp;<td>
+                              <td>
+                                <input type="button" value="Confirm" class="btn btn-success">
+                                <input type="button" value="Decline" class="btn btn-danger" onclick="deleteRow(this, 'matches')">
+                              </td>
+                            </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
                   </div>
               </div>
 


### PR DESCRIPTION
created the view for how matched students will be displayed.

Actually accepting and declining these meeting requests are part of different issues.

Since the matching is not in effect as I'm writing this you can either move issue #39 to Sprint 4 or you can accept this as a barebones **template** that is to be used to return matches.

As of now, every user will have two fake meetings. The buttons don't actually affect the database, this will be implemented once the meetings table is finalized so the meeting requests viewed are actual requests.

You **can** however  "Decline" the requests and if there are no more requests, the view will show

> No matches to display.

Your matches are organized by course, so every match will be grouped by the course they belong to.