### PR TITLE
#115 Sidebar properly links to each page seemlessly on the website.

### DIFF
--- a/app/resources/views/common.blade.php
+++ b/app/resources/views/common.blade.php
@@ -31,7 +31,7 @@
              Account Settings </a>
            </li>
            <li>
-             <a href="#">
+             <a href="/courseDisplay">
              Find a Buddy </a>
            </li>
            <li>

--- a/app/resources/views/common.blade.php
+++ b/app/resources/views/common.blade.php
@@ -23,7 +23,7 @@
        <div>
          <ul class="nav">
            <li class="active default">
-             <a href="#">
+             <a href="/home">
              Overview </a>
            </li>
            <li>
@@ -31,7 +31,7 @@
              Account Settings </a>
            </li>
            <li>
-             <a href="#" target="_blank">
+             <a href="#">
              Find a Buddy </a>
            </li>
            <li>


### PR DESCRIPTION
Changes made: Overview now links to `/home/`
Find a Buddy now links to `/courseDisplay/`

**The page `/courseDisplay/` is not yet on master therefore it will yield a "Not Found Exception" when trying to access it**

Issue #115 can be closed as navigation through any page on the website can be achieved.