### PR TITLE
Teacher filter

### DIFF
--- a/app/app/Http/Controllers/InstructorController.php
+++ b/app/app/Http/Controllers/InstructorController.php
@@ -19,16 +19,12 @@ class InstructorController extends Controller
         $courses = Auth::user()->courses;
         $teachers = collect();  //create empty collection
         foreach($courses as $course){
-            echo '<pre>'; print_r($course->users->pluck('name')); echo '</pre>';
             $teachers = $teachers->merge($course->users->where('title', '=', 'teacher')->pluck('id', 'name'));
         }
         $tas = collect();       //create empty collection
-        foreach($tas as $ta){
+        foreach($courses as $course){
             $tas = $tas->merge($course->users->where('title', '=', 'ta')->pluck('id', 'name'));
         }
         return view('instructors/chooseinstr', compact('teachers', 'tas'));
-
-
     }
-
 }

--- a/app/app/Http/Controllers/InstructorController.php
+++ b/app/app/Http/Controllers/InstructorController.php
@@ -5,8 +5,6 @@ namespace App\Http\Controllers;
 use DB;
 use App\User;
 use Illuminate\Http\Request;
-
-//getting current user authentication.
 use Illuminate\Support\Facades\Auth;
 
 class InstructorController extends Controller
@@ -18,14 +16,19 @@ class InstructorController extends Controller
     */
     public function index()
     {
-        
-        $teachers = User::where('title', '=', 'teacher')->pluck('id', 'name');
-
-        $tas = User::where('title', '=', 'ta')->pluck('id', 'name');
-
+        $courses = Auth::user()->courses;
+        $teachers = collect();  //create empty collection
+        foreach($courses as $course){
+            echo '<pre>'; print_r($course->users->pluck('name')); echo '</pre>';
+            $teachers = $teachers->merge($course->users->where('title', '=', 'teacher')->pluck('id', 'name'));
+        }
+        $tas = collect();       //create empty collection
+        foreach($tas as $ta){
+            $tas = $tas->merge($course->users->where('title', '=', 'ta')->pluck('id', 'name'));
+        }
         return view('instructors/chooseinstr', compact('teachers', 'tas'));
-        
-    	
+
+
     }
 
 }


### PR DESCRIPTION
Small change to the behaviour of the `Find an Instructor` page. Only Instructors and TAs with common enrollments as the user will be returned.

This was not previously the case, where all Instructors and TAs were returned.