### PR TITLE
Meeting tests

### DIFF
--- a/app/app/Http/Controllers/RequestController.php
+++ b/app/app/Http/Controllers/RequestController.php
@@ -31,6 +31,7 @@ class RequestController extends Controller
          $this->validate(request(), [
              'time' => 'required'
              ]);
+        date_default_timezone_set("America/New_York");
         $data = clone($request);
         //array is serialized in client
         //serialization allows an array to be passed as value

--- a/app/database/factories/ModelFactory.php
+++ b/app/database/factories/ModelFactory.php
@@ -41,7 +41,7 @@ $factory->define(App\Enrollment::class, function (Faker\Generator $faker) {
 
     return [
         'course_id' => $faker->numberBetween($min = 0, $max = 1),
-        'user_id' => $faker->numberBetween($min = 1, $max = 10),
+        'user_id' => $faker->unique()->numberBetween($min = 1, $max = 10),
     ];
 });
 

--- a/app/database/factories/ModelFactory.php
+++ b/app/database/factories/ModelFactory.php
@@ -41,7 +41,7 @@ $factory->define(App\Enrollment::class, function (Faker\Generator $faker) {
 
     return [
         'course_id' => $faker->numberBetween($min = 0, $max = 1),
-        'user_id' => $faker->unique()->numberBetween($min = 1, $max = 10),
+        'user_id' => $faker->numberBetween($min = 1, $max = 10),
     ];
 });
 

--- a/app/tests/Feature/meetingsTest.php
+++ b/app/tests/Feature/meetingsTest.php
@@ -52,7 +52,6 @@ class meetingsTest extends TestCase
      * NOTE : Test is highly dependent on “db:seed” command, should be refactored.
      */
      public function testCreateMeetingFailure(){
-
          $arr = $this->testCreateMeetingHelper();
          $student = $arr[0];
          $teacher = $arr[1];
@@ -61,7 +60,29 @@ class meetingsTest extends TestCase
              "instructor" => $teacher->id,
              "instructor-names-next" => null
          ]);
-         //if start_time not present. meeting should not be created
+         //if start_time not present,  assert that meeting is not be created
+       $this->assertTrue(\App\Meeting::get()->count() == 0);
+       $this->assertTrue(\App\Attendance::get()->count() == 0);
+     }
+
+     /**
+     * Test command meetings:closeExpired
+     * NOTE : Test is highly dependent on “db:seed” command, should be refactored.
+     */
+     public function testCloseExpiredMeetingsCommand(){
+       $arr = $this->testCreateMeetingHelper();
+       $student = $arr[0];
+       $teacher = $arr[1];
+       //create a meeting with an expired date
+       $response = $this->call('POST', '/instructorMeeting', [
+           '_token' => csrf_token(),
+           "currentWeek" => "1492315200",
+           "instructor" => $teacher->id,
+           "start_time" => "Sunday 12 AM",
+           "instructor-names-next" => null
+       ]);
+       $this->artisan("meetings:closeExpired");
+       //assert that meeting and corresponding attendances have been closed
        $this->assertTrue(\App\Meeting::get()->count() == 0);
        $this->assertTrue(\App\Attendance::get()->count() == 0);
      }

--- a/app/tests/Feature/meetingsTest.php
+++ b/app/tests/Feature/meetingsTest.php
@@ -17,44 +17,24 @@ class meetingsTest extends TestCase
     //use WithoutMiddleware;
     use DatabaseTransactions;
 
+    /**
+    * Test meeting creation success.
+    * NOTE : Test is highly dependent on "db:seed" command, should be refactored.
+    */
     public function testCreateMeetingSuccess(){
-        // $this->artisan("migrate:refresh");
-        // $this->artisan("db:seed");
-        // $course = \App\Course::find(1);
-        //get student and teacher enrolled in course
-        // $student = $course->users->where('title', '=', 'student')->values()->get(0);
-        // $teacher = $course->users->where('title', '=', 'teacher')->values()->get(0);
-        // Auth::login($student);
-        //
-        factory(User::class)->create([
-            'name' => 'bob',
-            'title' => 'student',
-            'email' => 'bob@bob.com',
-        ]);
-        factory(User::class)->create([
-            'name' => 'tom',
-            'title' => 'teacher',
-            'email' => 'tom@tom.com',
-        ]);
-        factory(Course::class)->create([
-            'code' => 'SOEN341',
-            'name' => 'Software Processes',
-        ]);
-        factory(Enrollment::class)->create([
-            'course_id' => '1',
-            'user_id' => '1',
-        ]);
-        factory(Enrollment::class)->create([
-            'course_id' => '1',
-            'user_id' => '2',
-        ]);
-        $student = User::where('name','=','bob');
-        $teacher = User::where('name','=','tom');
+        $this->artisan("db:seed");
+        $course = \App\Course::find(1);
+        if($course->users->count() < 2){
+          $course = \App\Course::find(2);
+        }
+        $student = $course->users->get(0);
+        $student->title = ('student');
+        $teacher = $course->users->get(1);
+        $teacher->title = ('teacher');
+        Auth::login($student);
         //seeded schedules are random, assign fixed values
         $student->schedule->freetime = "111011100010010011001100011111101001111100100010100011010000010110010110001011111010001010010100000001110101111100011011000000111011001010000110100101001001001001101010";
         $teacher->schedule->freetime = "101011100010010011001100011111101001111100100010100011010000010110010110001011111010001010010100000001110101111100011011000000111011001010000110100101001001001001101010";
-        // fwrite(STDERR, print_r($student->schedule->freetime, TRUE));
-        // fwrite(STDERR, print_r($teacher->schedule->freetime, TRUE));
         // fwrite(STDERR, print_r(Auth::user()->schedule->freetime, TRUE));
         //meeting time will occur in the past?
         $response = $this->call('POST', '/instructorMeeting', [
@@ -70,17 +50,13 @@ class meetingsTest extends TestCase
             'id' => '1',
             'instructorMeeting' => true
         ]);
-        // $this->seeInDatabase('attendances', [
-        //     'meeting_id' => '1',
-        //     'user_id' => $student->id
-        // ]);
-        // $this->seeInDatabase('attendances', [
-        //     'meeting_id' => '1',
-        //     'user_id' => $teacher->id
-        // ]);
-    }
-
-    // public function testDeclineMeetingSuccess(){
-    //
-    // }
+        $this->assertDatabaseHas('attendances', [
+            'meeting_id' => '1',
+            'user_id' => $student->id
+        ]);
+        $this->assertDatabaseHas('attendances', [
+            'meeting_id' => '1',
+            'user_id' => $teacher->id
+        ]);
+      }
 }

--- a/app/tests/Feature/meetingsTest.php
+++ b/app/tests/Feature/meetingsTest.php
@@ -60,7 +60,7 @@ class meetingsTest extends TestCase
              "instructor" => $teacher->id,
              "instructor-names-next" => null
          ]);
-         //if start_time not present,  assert that meeting is not be created
+         //if start_time not present in request, assert that meeting is not be created
        $this->assertTrue(\App\Meeting::get()->count() == 0);
        $this->assertTrue(\App\Attendance::get()->count() == 0);
      }
@@ -69,7 +69,7 @@ class meetingsTest extends TestCase
      * Test command meetings:closeExpired
      * NOTE : Test is highly dependent on “db:seed” command, should be refactored.
      */
-     public function testCloseExpiredMeetingsCommand(){
+     public function testCloseExpiredMeetingsSuccess(){
        $arr = $this->testCreateMeetingHelper();
        $student = $arr[0];
        $teacher = $arr[1];
@@ -81,6 +81,7 @@ class meetingsTest extends TestCase
            "start_time" => "Sunday 12 AM",
            "instructor-names-next" => null
        ]);
+       $this->assertTrue(\App\Meeting::get()->count() == 1);
        $this->artisan("meetings:closeExpired");
        //assert that meeting and corresponding attendances have been closed
        $this->assertTrue(\App\Meeting::get()->count() == 0);
@@ -94,6 +95,7 @@ class meetingsTest extends TestCase
        $this->artisan("db:seed");
        $course = \App\Course::find(1);
        if($course->users->count() < 2){
+         fwrite(STDERR, print_r(\App\Course::find(2)->users->count(), TRUE));
          $course = \App\Course::find(2);
        }
        $student = $course->users->get(0);

--- a/app/tests/Feature/meetingsTest.php
+++ b/app/tests/Feature/meetingsTest.php
@@ -33,7 +33,6 @@ class meetingsTest extends TestCase
         ]);
         //assert meeting created, and both student and teacher are attending
         $this->assertDatabaseHas('meetings', [
-            'course_id' => '1',
             'id' => '1',
             'instructorMeeting' => true
         ]);
@@ -92,6 +91,7 @@ class meetingsTest extends TestCase
      * NOTE : Test is highly dependent on behaviour of “db:seed” command, should be refactored.
      */
      public function testCreateMeetingHelper(){
+       $this->artisan("migrate:refresh");
        $this->artisan("db:seed");
        $course = \App\Course::find(1);
        while($course->users->count() < 2){
@@ -106,7 +106,7 @@ class meetingsTest extends TestCase
        //seeded schedules are random, assign fixed values
        $student->schedule->freetime = "111011100010010011001100011111101001111100100010100011010000010110010110001011111010001010010100000001110101111100011011000000111011001010000110100101001001001001101010";
        $teacher->schedule->freetime = "101011100010010011001100011111101001111100100010100011010000010110010110001011111010001010010100000001110101111100011011000000111011001010000110100101001001001001101010";
-       return array($student, $teacher);
+       return array($student, $teacher, $course);
      }
 
      // print to console during test

--- a/app/tests/Feature/meetingsTest.php
+++ b/app/tests/Feature/meetingsTest.php
@@ -94,8 +94,8 @@ class meetingsTest extends TestCase
      public function testCreateMeetingHelper(){
        $this->artisan("db:seed");
        $course = \App\Course::find(1);
-       if($course->users->count() < 2){
-         fwrite(STDERR, print_r(\App\Course::find(2)->users->count(), TRUE));
+       while($course->users->count() < 2){
+         $this->artisan("db:seed");
          $course = \App\Course::find(2);
        }
        $student = $course->users->get(0);

--- a/app/tests/Feature/meetingsTest.php
+++ b/app/tests/Feature/meetingsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+// use Tests\BrowserKitTestCase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Auth;
+use App\User;
+use App\Course;
+
+class meetingsTest extends TestCase
+{
+    use DatabaseMigrations;
+    //use WithoutMiddleware;
+    use DatabaseTransactions;
+
+    public function testCreateMeetingSuccess(){
+        // $this->artisan("migrate:refresh");
+        // $this->artisan("db:seed");
+        // $course = \App\Course::find(1);
+        //get student and teacher enrolled in course
+        // $student = $course->users->where('title', '=', 'student')->values()->get(0);
+        // $teacher = $course->users->where('title', '=', 'teacher')->values()->get(0);
+        // Auth::login($student);
+        //
+        factory(User::class)->create([
+            'name' => 'bob',
+            'title' => 'student',
+            'email' => 'bob@bob.com',
+        ]);
+        factory(User::class)->create([
+            'name' => 'tom',
+            'title' => 'teacher',
+            'email' => 'tom@tom.com',
+        ]);
+        factory(Course::class)->create([
+            'code' => 'SOEN341',
+            'name' => 'Software Processes',
+        ]);
+        factory(Enrollment::class)->create([
+            'course_id' => '1',
+            'user_id' => '1',
+        ]);
+        factory(Enrollment::class)->create([
+            'course_id' => '1',
+            'user_id' => '2',
+        ]);
+        $student = User::where('name','=','bob');
+        $teacher = User::where('name','=','tom');
+        //seeded schedules are random, assign fixed values
+        $student->schedule->freetime = "111011100010010011001100011111101001111100100010100011010000010110010110001011111010001010010100000001110101111100011011000000111011001010000110100101001001001001101010";
+        $teacher->schedule->freetime = "101011100010010011001100011111101001111100100010100011010000010110010110001011111010001010010100000001110101111100011011000000111011001010000110100101001001001001101010";
+        // fwrite(STDERR, print_r($student->schedule->freetime, TRUE));
+        // fwrite(STDERR, print_r($teacher->schedule->freetime, TRUE));
+        // fwrite(STDERR, print_r(Auth::user()->schedule->freetime, TRUE));
+        //meeting time will occur in the past?
+        $response = $this->call('POST', '/instructorMeeting', [
+            '_token' => csrf_token(),
+            "currentWeek" => "1492315200",
+            "instructor" => $teacher->id,
+            "start_time" => "Sunday 12 AM",
+            "instructor-names-next" => null
+        ]);
+        //assert meeting created, and both student and teacher are attending
+        $this->assertDatabaseHas('meetings', [
+            'course_id' => '1',
+            'id' => '1',
+            'instructorMeeting' => true
+        ]);
+        // $this->seeInDatabase('attendances', [
+        //     'meeting_id' => '1',
+        //     'user_id' => $student->id
+        // ]);
+        // $this->seeInDatabase('attendances', [
+        //     'meeting_id' => '1',
+        //     'user_id' => $teacher->id
+        // ]);
+    }
+
+    // public function testDeclineMeetingSuccess(){
+    //
+    // }
+}

--- a/app/tests/Feature/requestsTest.php
+++ b/app/tests/Feature/requestsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Auth;
+use App\User;
+use App\Course;
+
+class requestsTest extends TestCase
+{
+    use DatabaseMigrations;
+    use DatabaseTransactions;
+
+    /**
+    * Test meeting request creation success.
+    * NOTE : Test is highly dependent on "db:seed" command, should be refactored.
+    */
+    public function testCreateMeetingRequestSuccess(){
+      $arr = $this->testCreateMeetingRequestHelper();
+      $studentA = $arr[0];
+      $studentB = $arr[1];
+      $course = $arr[2];
+      //create a meeting request, note time is expired
+      $response = $this->call('POST', 'requests/create', [
+          '_token' => csrf_token(),``
+          "currentWeek" => "1492315200",
+          "time" => serialize(array("Sunday 12 AM", $studentB->id)),
+          "course_id" => $course->id
+      ]);
+      //assert request created, and both students are invited
+      $this->assertDatabaseHas('requests', [
+          'course_id' => $course->id,
+          'id' => '1'
+        ]);
+      $this->assertDatabaseHas('invites', [
+          'request_id' => '1',
+          'user_id' => $studentA->id,
+          'sender' => true
+      ]);
+      $this->assertDatabaseHas('invites', [
+          'request_id' => '1',
+          'user_id' => $studentB->id,
+          'sender' => false
+      ]);
+    }
+
+      /**
+     * Test meeting request creation failure.
+     * NOTE : Test is highly dependent on “db:seed” command, should be refactored.
+     */
+     public function testCreateMeetingRequestFailure(){
+       $arr = $this->testCreateMeetingRequestHelper();
+       $studentA = $arr[0];
+       $studentB = $arr[1];
+       $course = $arr[2];
+       //create a meeting request, note time is expired
+       $response = $this->call('POST', 'requests/create', [
+           "currentWeek" => "1492315200",
+          //  "time" => serialize(array("Sunday 12 AM", $studentB->id)),
+           "course_id" => $course->id
+       ]);
+       //if time not present in requset, assert that meetingrequest and invites are not created
+       $this->assertTrue(\App\Request::get()->count() == 0);
+       $this->assertTrue(\App\Invite::get()->count() == 0);
+     }
+
+     /**
+     * Test command requests:closeExpired
+     * NOTE : Test is highly dependent on “db:seed” command, should be refactored.
+     */
+     public function testCloseExpiredMeetingRequestsSuccess(){
+         $arr = $this->testCreateMeetingRequestHelper();
+         $studentA = $arr[0];
+         $studentB = $arr[1];
+         $course = $arr[2];
+         //create a meeting request, note time is expired
+         $response = $this->call('POST', 'requests/create', [
+             '_token' => csrf_token(),
+             "currentWeek" => "1492315200",
+             "time" => serialize(array("Sunday 12 AM", $studentB->id)),
+             "course_id" => $course->id
+         ]);
+         $this->assertTrue(\App\Request::get()->count() == 1);
+         $this->artisan("requests:closeExpired");
+         //assert that meeting and corresponding attendances have been closed
+         $this->assertTrue(\App\Request::get()->count() == 0);
+         $this->assertTrue(\App\Invite::get()->count() == 0);
+     }
+
+     /**
+     * NOTE : Test is highly dependent on behaviour of “db:seed” command, should be refactored.
+     */
+     public function testCreateMeetingRequestHelper(){
+       $this->artisan("db:seed");
+       $course = \App\Course::find(1);
+       if($course->users->count() < 2){
+         $course = \App\Course::find(2);
+       }
+       $studentA = $course->users->get(0);
+       $studentA->title = ('student');
+       $studentB = $course->users->get(1);
+       $studentB->title = ('student');
+       Auth::login($studentA);
+       //seeded schedules are random, assign fixed values
+       $studentA->schedule->freetime = "111011100010010011001100011111101001111100100010100011010000010110010110001011111010001010010100000001110101111100011011000000111011001010000110100101001001001001101010";
+       $studentB->schedule->freetime = "101011100010010011001100011111101001111100100010100011010000010110010110001011111010001010010100000001110101111100011011000000111011001010000110100101001001001001101010";
+       return array($studentA, $studentB, $course);
+     }
+
+     // print to console during test
+     // fwrite(STDERR, print_r(Auth::user()->schedule->freetime, TRUE));
+
+}

--- a/app/tests/Feature/requestsTest.php
+++ b/app/tests/Feature/requestsTest.php
@@ -94,7 +94,8 @@ class requestsTest extends TestCase
      /**
      * NOTE : Test is highly dependent on behaviour of “db:seed” command, should be refactored.
      */
-     public function testCreateMeetingRequestHelper(){ 
+     public function testCreateMeetingRequestHelper(){
+       $this->artisan("migrate:refresh");
        $this->artisan("db:seed");
        $course = \App\Course::find(1);
        while($course->users->count() < 2){

--- a/app/tests/Feature/requestsTest.php
+++ b/app/tests/Feature/requestsTest.php
@@ -94,7 +94,7 @@ class requestsTest extends TestCase
      /**
      * NOTE : Test is highly dependent on behaviour of “db:seed” command, should be refactored.
      */
-     public function testCreateMeetingRequestHelper(){
+     public function testCreateMeetingRequestHelper(){ 
        $this->artisan("db:seed");
        $course = \App\Course::find(1);
        while($course->users->count() < 2){

--- a/app/tests/Feature/requestsTest.php
+++ b/app/tests/Feature/requestsTest.php
@@ -26,7 +26,7 @@ class requestsTest extends TestCase
       $course = $arr[2];
       //create a meeting request, note time is expired
       $response = $this->call('POST', 'requests/create', [
-          '_token' => csrf_token(),``
+          '_token' => csrf_token(),
           "currentWeek" => "1492315200",
           "time" => serialize(array("Sunday 12 AM", $studentB->id)),
           "course_id" => $course->id
@@ -97,7 +97,8 @@ class requestsTest extends TestCase
      public function testCreateMeetingRequestHelper(){
        $this->artisan("db:seed");
        $course = \App\Course::find(1);
-       if($course->users->count() < 2){
+       while($course->users->count() < 2){
+         $this->artisan("db:seed");
          $course = \App\Course::find(2);
        }
        $studentA = $course->users->get(0);


### PR DESCRIPTION
Created feature tests for Meetings and Meeting Requests.
Although not all possible scenarios are covered, test coverage includes 

- create a meeting SUCCESS
- create a meeting FAILURE
- close expired meetings SUCCESS

- create a meeting request SUCCESS
- create a meeting request FAILURE
- close expired meeting requests SUCCESS

ISSUE : Sometimes, the `db:seed` command fails and causes the feature tests to fail